### PR TITLE
Fixed prototype pollution in merge-options

### DIFF
--- a/build.js
+++ b/build.js
@@ -23,6 +23,10 @@ var getEnumerableOwnPropertyKeys = function getEnumerableOwnPropertyKeys(value) 
   var keys = [];
 
   for (var key in value) {
+    // prototype pollution mitigation
+    if(key.includes('__proto__') || key.includes('constructor') || key.includes('prototype')){
+      return keys;
+    }
     if (hasOwnProperty.call(value, key)) {
       keys.push(key);
     }

--- a/index.js
+++ b/index.js
@@ -19,6 +19,10 @@ const getEnumerableOwnPropertyKeys = value => {
 	const keys = [];
 
 	for (const key in value) {
+		// prototype pollution mitigation
+		if(key.includes('__proto__') || key.includes('constructor') || key.includes('prototype')){
+			return keys;
+		}
 		if (hasOwnProperty.call(value, key)) {
 			keys.push(key);
 		}


### PR DESCRIPTION
### 📊 Metadata *

Prototype Pollution bug

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-merge-options-es5

### ⚙️ Description *

merge-options is vulnerable to Prototype Pollution.. This package allowing for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE.

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.

### 💻 Technical Description *

The bug is fixed by validating the input `key` to check for prototypes. It is implemented by a simple validation to check for prototype keywords `(__proto__, constructor and prototype)`, where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability. 

### 🐛 Proof of Concept (PoC) *

Clone the project, install the required dependencies and on running the below snippet of code, it triggers prototype pollution and logs `true`.
```javascript
// poc.js
merge = require('merge-options-es5')

console.log('Before: ', {}.polluted)
merge({}, JSON.parse('{"__proto__": {"polluted": true}}'))
console.log('After: ', {}.polluted)
```



### 🔥 Proof of Fix (PoF) *

After the fix is applied, it returns `undefined` since the polluted referred in the PoC is no more accessible(which is intended). Hence fixing the issue.


### 👍 User Acceptance Testing (UAT)

Just prevented some keywords as `key` and no breaking changes are introduced. :)
